### PR TITLE
Fix broken link for network cookbook tutorial

### DIFF
--- a/020-book_list.Rmd
+++ b/020-book_list.Rmd
@@ -1604,7 +1604,7 @@ The book is free and work in progress. <https://mlr3book.mlr-org.com/>
 
 Sacha Epskamp
 
-<http://sachaepskamp.com/files/Cookbook.html>
+<https://web.archive.org/web/20210414173702/http://sachaepskamp.com/files/Cookbook.html>
 
 
 ## Statistical Analysis of Network Data with R


### PR DESCRIPTION
Link formerly linked to author's homepage rather than the resource
itself. Although the author notes that this tutorial is out of date,
this can be kept as a good enough resource to start with network
analysis.