### PR TITLE
add free links to CAC book

### DIFF
--- a/chapters/Social Science.qmd
+++ b/chapters/Social Science.qmd
@@ -63,13 +63,15 @@ Link: [https://bluefoxr.github.io/COINrDoc/](https://bluefoxr.github.io/COINrDoc
 
 ## Computational Analysis of Communication
 
-- [Wouter van Atteveldt](https://twitter.com/vanatteveldt)
-- Damian Trilling
+- [Wouter van Atteveldt](https://vanatteveldt.com)
+- [Damian Trilling](https://www.damiantrilling.net/)
 - Carlos Arcila Calderon
 
 Assuming little or no background in data science or computer linguistics, this accessible textbook teaches readers how to use state-of-the art computational methods to perform data-driven analyses of social science issues. A cross-disciplinary team of authors—with expertise in both the social sciences and computer science—explains how to gather and clean data, manage textual, audio-visual, and network data, conduct statistical and quantitative analysis, and interpret, summarize, and visualize the results.
 
-Link: [https://www.wiley.com/en-us/Computational+Analysis+of+Communication-p-9781119680239](https://www.wiley.com/en-us/Computational+Analysis+of+Communication-p-9781119680239)
+Link: [http://cssbook.net/](http://cssbook.net/)
+Link (draft 2nd edition): [https://v2.cssbook.net/](https://v2.cssbook.net/)
+Link print: [https://www.wiley.com/en-us/Computational+Analysis+of+Communication-p-9781119680239](https://www.wiley.com/en-us/Computational+Analysis+of+Communication-p-9781119680239)
 
 ## Computational Social Science: Theory & Application
 


### PR DESCRIPTION
noticed you only had the print version of Computational Analysis of Communication. I added the free online version and draft of 2nd edition. Feel free to discard and make the changes yourself.